### PR TITLE
make entries with legacy class names backwards compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ If previously the `akka-persistence-mongo` library was used together with Akka a
 complete stack should be migrated to Pekko, Pekko-Persistence and `pekko-persistence-mongo` as a replacement, the
 following section describes migration steps to take.
 
+If you are using a feature of Akka that uses persistence under the hood and potentially persists the full Akka class name as a part
+of the persistence data (classic PersistentFSM is a known example), then this module will implicitly translate that data when reading
+to the Pekko class name to be able to deserialize it and keep compatibility. The opposite is true if you migrate and find an issue with
+your Pekko migration and need to roll back, but your application has already persisted entries with the new Pekko class name. The same functionality
+has been backported to allow rolling back your application, but you must be on `akka-persistence-mongo` version **4.0.0** to have this translation.
+
 The root configuration key changed from `akka` to `pekko`, so adjust your configuration accordingly, e.g.  
 from:
 ```hocon

--- a/scala/src/main/scala/pekko/contrib/persistence/mongodb/MongoDataModel.scala
+++ b/scala/src/main/scala/pekko/contrib/persistence/mongodb/MongoDataModel.scala
@@ -49,7 +49,7 @@ case class Serialized[C <: AnyRef](bytes: Array[Byte],
   val hint = "ser"
   lazy val content: C = {
     val clazz = loadClass.getClassFor[X forSome { type X <: AnyRef }](className)
-    val backwardsCompatClazz = loadClass.getClassFor[X forSome { type X <: AnyRef }](className.replace("akka", "org.apache.pekko"))
+    def backwardsCompatClazz = loadClass.getClassFor[X forSome { type X <: AnyRef }](className.replace("akka", "org.apache.pekko"))
     Try(tryDeserialize(clazz, clazz.flatMap(c => Try(ser.serializerFor(c)))))
       .recover({
         case _ => tryDeserialize(backwardsCompatClazz, backwardsCompatClazz.flatMap(c => Try(ser.serializerFor(c))))


### PR DESCRIPTION
fixes the issue where features of akka / pekko that are dependent on the persistence module and will potentially store the class name of an akka / pekko class as a part of the persisted data. 