### PR TITLE
Cross-building to Scala 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,20 @@ jobs:
             scala-version: 2.12.18
           - mongo-version: 4.4
             scala-version: 2.13.11
+          - mongo-version: 4.4
+            scala-version: 3.3.0
           - mongo-version: "5.0" # 5.0 must be quoted, otherwise will be truncated to 5
             scala-version: 2.12.18
           - mongo-version: "5.0"
             scala-version: 2.13.11
+          - mongo-version: "5.0"
+            scala-version: 3.3.0
           - mongo-version: "6.0"
             scala-version: 2.12.18
           - mongo-version: "6.0"
             scala-version: 2.13.11
+          - mongo-version: "6.0"
+            scala-version: 3.3.0
     env:
       MONGODB_AUTH_PORT: 28117
       MONGODB_NOAUTH_PORT: 27117

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 * The tests expect two mongods running, with and without authentication. A utility script (`test_containers.sh`) will boot these as docker containers.
 * Supports Pekko 1.0.0
 * Test suite runs against MongoDB major versions 4.4, 5.0, 6.0
-* Cross-compiled against scala `2.12` and `2.13`
+* Cross-compiled against scala `2.12`, `2.13` and `3` - *WARNING* in the case of Scala 3 this library uses `2.13` version of `mongo-scala-driver`, because it is not yet available for Scala 3.
 * Be aware that there is a `16MB` payload size limit on snapshots and journal events.  In addition a journal batch must be <= `16MB` in size.  A journal batch is defined by the `Seq` of events passed to `persistAll`.
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,7 @@ publish / skip := true
 
 val scala212V = "2.12.18"
 val scala213V = "2.13.11"
+val scala3V = "3.3.0"
 
 val scalaV = scala213V
 val pekkoV = "1.0.1"
@@ -25,10 +26,10 @@ val commonDeps = Seq(
   "org.apache.logging.log4j"  % "log4j-core"                % Log4jVersion  % "test",
   "org.apache.logging.log4j"  % "log4j-slf4j-impl"          % Log4jVersion  % "test",
   "org.scalatest"             %% "scalatest"                % "3.2.16"   % "test",
-  "org.scalatestplus"         %% "mockito-1-10"             % "3.1.0.0" % "test",
-  "org.scalatestplus"         %% "junit-4-12"               % "3.2.2.0" % "test",
+  "org.scalatestplus"         %% "mockito-5-10"             % "3.2.18.0" % "test",
+  "org.scalatestplus"         %% "junit-4-13"               % "3.2.18.0" % "test",
   "junit"                     % "junit"                     % "4.13.2"    % "test",
-  "org.mockito"               % "mockito-all"               % "1.10.19" % "test",
+  "org.mockito"               % "mockito-core"              % "5.10.0" % "test",
   "org.apache.pekko"         %% "pekko-slf4j"               % pekkoV     % "test",
   "org.apache.pekko"         %% "pekko-testkit"             % pekkoV     % "test",
   "org.apache.pekko"         %% "pekko-persistence-tck"     % pekkoV     % "test",
@@ -63,7 +64,7 @@ ThisBuild / homepage := Some(url("https://github.com/scullxbones/pekko-persisten
 
 val commonSettings = Seq(
   scalaVersion := scalaV,
-  crossScalaVersions := Seq(scala212V, scala213V),
+  crossScalaVersions := Seq(scala212V, scala213V, scala3V),
   libraryDependencies ++= commonDeps,
   dependencyOverrides ++= Seq(
     "com.typesafe" % "config" % "1.4.2",
@@ -107,8 +108,8 @@ lazy val `pekko-persistence-mongodb` = (project in file("scala"))
   .settings(commonSettings:_*)
   .settings(
     libraryDependencies ++= Seq(
-      "org.mongodb.scala" %% "mongo-scala-driver" % MongoJavaDriverVersion % "compile",
-      "org.mongodb.scala" %% "mongo-scala-bson"   % MongoJavaDriverVersion % "compile",
+      "org.mongodb.scala" %% "mongo-scala-driver" % MongoJavaDriverVersion % "compile" cross CrossVersion.for3Use2_13,
+      "org.mongodb.scala" %% "mongo-scala-bson"   % MongoJavaDriverVersion % "compile" cross CrossVersion.for3Use2_13,
       "io.netty"          % "netty-buffer"        % NettyVersion           % "compile",
       "io.netty"          % "netty-transport"     % NettyVersion           % "compile",
       "io.netty"          % "netty-handler"       % NettyVersion           % "compile",
@@ -124,7 +125,7 @@ lazy val `pekko-persistence-mongo-tools` = (project in file("tools"))
   .settings(commonSettings:_*)
   .settings(
     libraryDependencies ++= Seq(
-      "org.mongodb.scala" %% "mongo-scala-driver" % MongoJavaDriverVersion % "compile"
+      "org.mongodb.scala" %% "mongo-scala-driver" % MongoJavaDriverVersion % "compile" cross CrossVersion.for3Use2_13
     ),
     publish / skip := true
   )

--- a/scala/src/main/scala/pekko/contrib/persistence/mongodb/ReflectiveLookupExtension.scala
+++ b/scala/src/main/scala/pekko/contrib/persistence/mongodb/ReflectiveLookupExtension.scala
@@ -9,7 +9,7 @@ object ReflectiveLookupExtension extends ExtensionId[ReflectiveLookupExtension] 
   override def createExtension(system: ExtendedActorSystem): ReflectiveLookupExtension =
     new ReflectiveLookupExtension(system)
 
-  override def lookup(): ExtensionId[ReflectiveLookupExtension] = ReflectiveLookupExtension
+  override def lookup: ExtensionId[ReflectiveLookupExtension] = ReflectiveLookupExtension
 }
 
 class ReflectiveLookupExtension(extendedActorSystem: ExtendedActorSystem) extends Extension {

--- a/scala/src/main/scala/pekko/contrib/persistence/mongodb/driver/ScalaDriverSettings.scala
+++ b/scala/src/main/scala/pekko/contrib/persistence/mongodb/driver/ScalaDriverSettings.scala
@@ -19,7 +19,7 @@ object ScalaDriverSettings extends ExtensionId[ScalaDriverSettings] with Extensi
     new ScalaDriverSettings(systemConfig.getConfig(fullPath))
   }
 
-  override def lookup(): ExtensionId[ScalaDriverSettings] = ScalaDriverSettings
+  override def lookup: ExtensionId[ScalaDriverSettings] = ScalaDriverSettings
 
 }
 
@@ -54,7 +54,7 @@ class ScalaDriverSettings(config: Config) extends OfficialDriverSettings(config)
           .maxConnectionLifeTime(getLongQueryProperty("maxlifetimems").getOrElse(MaxConnectionLifeTime.toMillis), TimeUnit.MILLISECONDS)
           .minSize(getIntQueryProperty("minpoolsize").getOrElse(MinConnectionsPerHost))
           .maxSize(getIntQueryProperty("maxpoolsize").getOrElse(ConnectionsPerHost))
-          ()
+        ()
       }.applyToServerSettings((t: ServerSettings.Builder) => {
       t.heartbeatFrequency(getLongQueryProperty("heartbeatfrequencyms").getOrElse(HeartbeatFrequency.toMillis), TimeUnit.MILLISECONDS)
         .minHeartbeatFrequency(MinHeartbeatFrequency.toMillis, TimeUnit.MILLISECONDS) // no 'minHeartbeatFrequency' in ConnectionString

--- a/scala/src/test/scala/pekko/contrib/persistence/mongodb/Journal1kSpec.scala
+++ b/scala/src/test/scala/pekko/contrib/persistence/mongodb/Journal1kSpec.scala
@@ -47,7 +47,7 @@ abstract class Journal1kSpec(extensionClass: Class[_], database: String, extende
   import concurrent.duration._
 
   "A counter" should "persist the counter to 1000" taggedAs Slow in withConfig(config(extensionClass), "pekko-contrib-mongodb-persistence-journal", "1k-test-persist") { case (as,config) =>
-    implicit val askTimeout = Timeout(2.minutes)
+    implicit val askTimeout: Timeout = Timeout(2.minutes)
     val counter = as.actorOf(Counter.props, id)
     (1 to 1000).foreach(_ => counter ! Inc)
     val result = (counter ? GetCounter).mapTo[Int]
@@ -57,7 +57,7 @@ abstract class Journal1kSpec(extensionClass: Class[_], database: String, extende
   }
 
   it should "restore the counter back to 1000"  taggedAs Slow in withConfig(config(extensionClass), "pekko-contrib-mongodb-persistence-journal", "1k-test-restore") { case (as, config) =>
-    implicit val askTimeout = Timeout(2.minutes)
+    implicit val askTimeout: Timeout = Timeout(2.minutes)
     val counter = as.actorOf(Counter.props, id)
     val result = (counter ? GetCounter).mapTo[Int]
     whenReady(result, timeout(askTimeout.duration + 10.seconds)) { onek =>

--- a/scala/src/test/scala/pekko/contrib/persistence/mongodb/JournalTaggingSpec.scala
+++ b/scala/src/test/scala/pekko/contrib/persistence/mongodb/JournalTaggingSpec.scala
@@ -178,9 +178,9 @@ abstract class JournalTaggingSpec(extensionClass: Class[_], database: String, ex
       readJournal
         .eventsByTag("qux", Offset.noOffset)
         .viaMat(KillSwitches.single)(Keep.right)
-        .toMat(Sink.actorRef(target.ref, "done", Status.Failure))(Keep.left).run()
+        .toMat(Sink.actorRef(target.ref, "done", Status.Failure.apply))(Keep.left).run()
     try {
-      target.receiveN(3).map(_.asInstanceOf[EventEnvelope].persistenceId) should contain only(pids:_*)
+      target.receiveN(3).map(_.asInstanceOf[EventEnvelope].persistenceId) should contain theSameElementsAs(pids)
       val newPa = as.actorOf(Taggarific.props("qux"),"tag-qux")
       deathWatch.send(newPa, Taggarific.TaggedEvent("qux", Set("foo","bar","qux")))
       deathWatch.expectMsg(Taggarific.Persisted)

--- a/scala/src/test/scala/pekko/contrib/persistence/mongodb/MongoPersistenceSpec.scala
+++ b/scala/src/test/scala/pekko/contrib/persistence/mongodb/MongoPersistenceSpec.scala
@@ -13,7 +13,7 @@ import scala.concurrent.ExecutionContext
 
 trait MongoPersistenceSpec[D,C] extends BaseUnitTest with ContainerMongo with BeforeAndAfterAll { self: TestKit =>
 
-  implicit val callerRuns = new ExecutionContext {
+  implicit val callerRuns: ExecutionContext = new ExecutionContext {
     def reportFailure(t: Throwable): Unit = { throw t }
     def execute(runnable: Runnable): Unit = { runnable.run() }
   }

--- a/scala/src/test/scala/pekko/contrib/persistence/mongodb/ReadJournalSpec.scala
+++ b/scala/src/test/scala/pekko/contrib/persistence/mongodb/ReadJournalSpec.scala
@@ -154,7 +154,7 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
       val ks =
         readJournal.allEvents()
           .viaMat(KillSwitches.single)(Keep.right)
-          .toMat(Sink.actorRef[EventEnvelope](probe.ref, 'complete, Status.Failure))(Keep.left)
+          .toMat(Sink.actorRef[EventEnvelope](probe.ref, Symbol("complete"), Status.Failure.apply(_)))(Keep.left)
           .run()
       Thread.sleep(1000L)
 
@@ -230,7 +230,7 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
       val readJournal =
         PersistenceQuery(as).readJournalFor[ScalaDslMongoReadJournal](MongoReadJournal.Identifier)
 
-      readJournal.currentPersistenceIds().runWith(Sink.actorRef(probe.ref, 'complete, Status.Failure))
+      readJournal.currentPersistenceIds().runWith(Sink.actorRef(probe.ref, Symbol("complete"), Status.Failure.apply))
 
       probe.receiveN(6, 5.seconds.dilated) should contain allOf ("1", "2", "3", "4", "5")
 
@@ -312,7 +312,7 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
       val ks =
         readJournal.persistenceIds()
           .viaMat(KillSwitches.single)(Keep.right)
-          .toMat(Sink.actorRef(probe.ref, 'complete, Status.Failure))(Keep.left)
+          .toMat(Sink.actorRef(probe.ref, Symbol("complete"), Status.Failure.apply))(Keep.left)
           .run()
 
       ars slice (3, 5) foreach { ar =>
@@ -378,7 +378,7 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
       val ks = readJournal
         .eventsByPersistenceId("foo-live", 2L, 3L)
         .viaMat(KillSwitches.single)(Keep.right)
-        .toMat(Sink.actorRef(probe.ref, 'complete, Status.Failure))(Keep.left)
+        .toMat(Sink.actorRef(probe.ref, Symbol("complete"), Status.Failure.apply))(Keep.left)
         .run()
 
       Thread.sleep(1000L)
@@ -414,7 +414,7 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
       val ks = readJournal
         .eventsByPersistenceId("foo-long-running", 2L, 3L)
         .viaMat(KillSwitches.single)(Keep.right)
-        .toMat(Sink.actorRef(probe.ref, 'complete, Status.Failure))(Keep.left)
+        .toMat(Sink.actorRef(probe.ref, Symbol("complete"), Status.Failure.apply))(Keep.left)
         .run()
 
       Thread.sleep(1.minute.toMillis)
@@ -499,7 +499,7 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
 
       val sources = (1 to nrOfActors) map (nr => readJournal.eventsByPersistenceId(s"pid-$nr", 0, Long.MaxValue))
 
-      val sink = Sink.actorRef(probe.ref, "complete", Status.Failure)
+      val sink = Sink.actorRef(probe.ref, "complete", Status.Failure.apply)
 
       val ks = sources.reduce(_ merge _).viaMat(KillSwitches.single)(Keep.right).toMat(sink)(Keep.left).run()
 

--- a/scala/src/test/scala/pekko/contrib/persistence/mongodb/driver/ScalaDriverPersistenceSpec.scala
+++ b/scala/src/test/scala/pekko/contrib/persistence/mongodb/driver/ScalaDriverPersistenceSpec.scala
@@ -7,6 +7,7 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatestplus.junit.JUnitRunner
 import pekko.contrib.persistence.mongodb.ConfigLoanFixture.withConfig
 import pekko.contrib.persistence.mongodb.{BaseUnitTest, ContainerMongo}
+import org.mongodb.scala.ObservableFuture
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}


### PR DESCRIPTION
Fixes https://github.com/scullxbones/pekko-persistence-mongo/issues/13
`mongo-scala-driver` doesn't have a scala 3 version, but `CrossVersion.for3Use2_13` seems to work well enough in this case