### PR TITLE
Update mongo-java-driver to 5.7.0 and use native Scala 3 artifacts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ val scala3V = "3.8.3"
 val scalaV = scala213V
 val pekkoV = "1.6.0"
 
-val MongoJavaDriverVersion = "5.6.5"
+val MongoJavaDriverVersion = "5.7.0"
 val NettyVersion = "4.2.12.Final"
 val Log4jVersion = "2.25.4"
 
@@ -109,8 +109,8 @@ lazy val `pekko-persistence-mongodb` = (project in file("scala"))
   .settings(commonSettings:_*)
   .settings(
     libraryDependencies ++= Seq(
-      "org.mongodb.scala" %% "mongo-scala-driver" % MongoJavaDriverVersion % "compile" cross CrossVersion.for3Use2_13,
-      "org.mongodb.scala" %% "mongo-scala-bson"   % MongoJavaDriverVersion % "compile" cross CrossVersion.for3Use2_13,
+      "org.mongodb.scala" %% "mongo-scala-driver" % MongoJavaDriverVersion % "compile",
+      "org.mongodb.scala" %% "mongo-scala-bson"   % MongoJavaDriverVersion % "compile",
       "io.netty"          % "netty-buffer"        % NettyVersion           % "compile",
       "io.netty"          % "netty-transport"     % NettyVersion           % "compile",
       "io.netty"          % "netty-handler"       % NettyVersion           % "compile",
@@ -126,7 +126,7 @@ lazy val `pekko-persistence-mongo-tools` = (project in file("tools"))
   .settings(commonSettings:_*)
   .settings(
     libraryDependencies ++= Seq(
-      "org.mongodb.scala" %% "mongo-scala-driver" % MongoJavaDriverVersion % "compile" cross CrossVersion.for3Use2_13
+      "org.mongodb.scala" %% "mongo-scala-driver" % MongoJavaDriverVersion % "compile"
     ),
     publish / skip := true
   )

--- a/scala/src/test/scala/pekko/contrib/persistence/mongodb/driver/ScalaDriverPersistenceSpec.scala
+++ b/scala/src/test/scala/pekko/contrib/persistence/mongodb/driver/ScalaDriverPersistenceSpec.scala
@@ -75,7 +75,7 @@ class ScalaDriverPersistenceAuthSpec extends BaseUnitTest with ContainerMongo wi
 
   "A secured mongodb instance" should "be connectable via user and pass" in withConfig(authConfig,"pekko-contrib-mongodb-persistence-journal","authentication-config") { case (actorSystem, config) =>
     val underTest = new ScalaMongoDriver(actorSystem, config)
-    val collections = Await.result(underTest.db.listCollectionNames().toFuture,3.seconds)
+    val collections = Await.result(underTest.db.listCollectionNames().toFuture(), 3.seconds)
     collections should contain ("system.users")
     ()
   }


### PR DESCRIPTION
## Summary
- Bumps `mongo-java-driver` from 5.6.5 → 5.7.0.
- Drops the three `cross CrossVersion.for3Use2_13` workarounds in `build.sbt` now that `mongo-scala-driver_3` / `mongo-scala-bson_3` are published on Maven Central.
- Fixes one stray `.toFuture` call site (the only one in the codebase missing the empty argument list — flagged by the Scala 3 native compile because `toFuture` is a parameterless extension method).

Resolves #226.

## Test plan
- [x] `sbt ++3.8.3 Test/compile` (both modules) — clean
- [x] `sbt ++2.13.18 Test/compile` (both modules) — clean
- [x] `sbt ++2.12.21 Test/compile` (both modules) — clean
- [x] Full CI matrix (3.8.3 / 2.13.18 / 2.12.21 against MongoDB 4.4 – 8.0) — relying on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)