### PR TITLE
Document server-default fallback for Acknowledged/Journaled write concerns

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ pekko.contrib.persistence.mongodb.mongo.snaps-collection = "my_persistent_snapsh
 pekko.contrib.persistence.mongodb.mongo.snaps-index = "my_snaps_index"
 pekko.contrib.persistence.mongodb.mongo.metadata-collection = "my_metadata_collection"
 pekko.contrib.persistence.mongodb.mongo.metadata-index = "my_metadata_index"
-pekko.contrib.persistence.mongodb.mongo.journal-write-concern = "Acknowledged"
+pekko.contrib.persistence.mongodb.mongo.journal-write-concern = "W1"
 ```
 
 <a name="collectioncaches"/>
@@ -254,9 +254,10 @@ This is well described in the [MongoDB Write Concern Documentation](http://docs.
 The write concern can be set both for the journal plugin as well as the snapshot plugin.  Every level of write concern is supported.  The possible concerns are listed below in decreasing safety:
 
 * `ReplicaAcknowledged` (a.k.a "majority") - requires the majority of the replica to acknowledge the write, this confirms that at least two servers have seen the write
-* `Journaled` <DEFAULT> - requires that the change be journaled on the server that was written to.  Other replicas may not see this write on a network partition
+* `Journaled` <DEFAULT> - requires that the change be journaled on the server that was written to.  Other replicas may not see this write on a network partition.
+  * **Warning**: This setting maps to `WriteConcern.JOURNALED`, which sends `{j: true}` on the wire without an explicit `w` value, so the MongoDB server applies its effective default for `w`. On a MongoDB 5.0+ replica set the implicit default is `w: majority`, and any cluster with `setDefaultRWConcern` configured will likewise override `w`. To pin the client-side write concern to "primary only", configure `W1` explicitly (note: `W1` does not include journaling — combine with care depending on your durability requirements).
 * `Acknowledged` - also known as "Safe", requires that the MongoDB server acknowledges the write.  This does not require that the change be persistent anywhere but memory.
-  * **Warning**: This setting uses the default write concern configured on the server.
+  * **Warning**: This setting maps to `WriteConcern.ACKNOWLEDGED`, which sends no explicit `w` value on the wire, so the MongoDB server applies its effective default. On a MongoDB 5.0+ replica set the implicit default is `w: majority`, and any cluster with `setDefaultRWConcern` configured will likewise override `w`. Use `W1` if you need a guaranteed client-side `w: 1` regardless of server defaults.
 * `W1` - requires that the MongoDB primary acknowledges the write.  This does not require that the change be persistent anywhere but memory.
 * `W2` - requires that the MongoDB primary and an additional secondary acknowledges the write.  This does not require that the change be persistent anywhere but memory.
 * `W3` - requires that the MongoDB primary and two additional secondaries acknowledges the write.  This does not require that the change be persistent anywhere but memory.

--- a/scala/src/main/resources/reference.conf
+++ b/scala/src/main/resources/reference.conf
@@ -15,7 +15,7 @@ pekko {
           journal-index = "pekko_persistence_journal_index"
           journal-seq-nr-index = "max_sequence_sort"
           journal-tag-index = "journal_tag_index"
-          # Write concerns are one of: Unacknowledged, Acknowledged, Journaled, ReplicaAcknowledged
+          # Write concerns are one of: Unacknowledged, Acknowledged, W1, W2, W3, Journaled, ReplicaAcknowledged
           journal-write-concern = "Journaled"
           journal-wtimeout = 3s
           journal-fsync = false


### PR DESCRIPTION
## Summary

Refs #230.

Documentation-only follow-up to the issue raised in #230. Since
`mongodb-java-driver` 4.0, `WriteConcern.ACKNOWLEDGED` is defined as
`new WriteConcern(null, null, null)` and serializes with no explicit
`w` field on the wire, so the MongoDB server applies its effective
default write concern. On a MongoDB 5.0+ replica set the implicit
default is `w: majority`, and any cluster with `setDefaultRWConcern`
configured will likewise override `w`.

The plugin already maps `Acknowledged` directly to
`WriteConcern.ACKNOWLEDGED`, which is the documented driver behavior —
remapping it to `W1` would itself be surprising. However:

- The same caveat applies to `WriteConcern.JOURNALED`, which is built
  as `ACKNOWLEDGED.withJournal(true)` and inherits `w = null`.
- `Journaled` is the **default** in `reference.conf`, so out-of-the-box
  installs on MongoDB 5.0+ replica sets effectively run with
  `{w: majority, j: true}` rather than the `{w: 1, j: true}` that the
  README description ("change be journaled on the server that was
  written to") implies.
- The previous one-line warning under `Acknowledged` did not explain
  *why* the server default applies or how to opt out.
- `W1`, `W2`, `W3` were added in v1.2.0 but were missing from the
  inline list of valid values in `reference.conf`.

## Changes

- `README.md`: expand the warning under `Acknowledged` and add an
  equivalent warning under `Journaled`, both pointing users at `W1`
  for an explicit client-side `w: 1`.
- `README.md`: switch the configuration example from `Acknowledged`
  to `W1`.
- `scala/src/main/resources/reference.conf`: add `W1, W2, W3` to the
  inline list of valid write-concern values.

No code/behavior changes — the reporter's workaround (configure `W1`
explicitly) remains the recommended path.
